### PR TITLE
Run commands in background

### DIFF
--- a/pkg/service/repo.go
+++ b/pkg/service/repo.go
@@ -68,7 +68,7 @@ func (r *Repository) update() error {
 	}
 
 	if len(r.Config.PostPullExec) > 0 {
-		r.runPostPullExec()
+		go r.runPostPullExec()
 	}
 
 	return nil


### PR DESCRIPTION
I run my static site builder as a post commands, and without running the command in the background it pretty much downs my site for a few seconds every time the command is executed.